### PR TITLE
Add support for mastodon instances other than `mastodon.social`

### DIFF
--- a/data/social.toml
+++ b/data/social.toml
@@ -66,7 +66,7 @@ weight = 110
 
 [[icons]]
 id = "mastodon"
-url = "https://mastodon.social/@%s"
+url = "https://%s/@%s"
 icon = "svg/mastodon.svg"
 weight = 120
 

--- a/layouts/partials/footer_social.html
+++ b/layouts/partials/footer_social.html
@@ -2,50 +2,7 @@
 <div class="footer__social social">
 	{{- range sort .Site.Data.social.icons "weight" }}
 		{{- if isset $.Site.Params.Social .id }}
-		{{- $url := ""}}
-		{{- if eq .id "mastodon"}}
-			{{- $raw := (index $.Site.Params.Social .id)}}
-			{{- $parts := split $raw "@"}}
-			{{- $instance := "mastodon.social"}}
-			{{- $username := $raw}}
-			{{- if eq (len $parts) 1}}
-				{{- /* maintain compat with original (see #8) */}}
-			{{- else if eq (len $parts) 2}}
-				{{- if eq (index $parts 0) ""}}
-					{{- /* parse local usernames relative to mastodon.social */}}
-					{{- if eq (index $parts 1) ""}}
-						{{errorf "failed to parse mastodon username %q: no username or instance" $raw}}
-					{{end}}
-					{{- $username = index $parts 1}}
-				{{- else}}
-					{{- /* parse usernames written in email format */}}
-					{{- if eq (index $parts 1) ""}}
-						{{errorf "failed to parse mastodon username %q: invalid format" $raw}}
-					{{end}}
-					{{- $username = index $parts 0}}
-					{{- $instance = index $parts 1}}
-				{{- end}}
-			{{- else if eq (len $parts) 3}}
-				{{- /* parse mastodon usernames written correctly */}}
-				{{- if ne (index $parts 0) ""}}
-					{{errorf "failed to parse mastodon username %q: leading garbage" $raw}}
-				{{end}}
-				{{- if eq (index $parts 1) ""}}
-					{{errorf "failed to parse mastodon username %q: missing username" $raw}}
-				{{end}}
-				{{- if eq (index $parts 2) ""}}
-					{{errorf "failed to parse mastodon username %q: missing instance" $raw}}
-				{{- end}}
-				{{- $username = index $parts 1}}
-				{{- $instance = index $parts 2}}
-			{{- else}}
-				{{errorf "failed to parse mastodon username %q: too many @'s" $raw}}
-			{{end}}
-			{{- $url = printf .url $instance $username}}
-		{{- else}}
-			{{- $url = printf .url (index $.Site.Params.Social .id)}}
-		{{- end}}
-		<a class="social__link" target="_blank" rel="noopener noreferrer" href="{{ $url }}">
+		<a class="social__link" target="_blank" rel="noopener noreferrer" href="{{if eq .id "mastodon"}}{{partial "footer_social_mastodonurl.tmpl" (index $.Site.Params.Social .id)}}{{else}}{{printf .url (index $.Site.Params.Social .id)}}{{end}}">
 			{{ partial .icon (dict "class" "social__icon") }}
 		</a>
 		{{- end }}

--- a/layouts/partials/footer_social.html
+++ b/layouts/partials/footer_social.html
@@ -2,7 +2,50 @@
 <div class="footer__social social">
 	{{- range sort .Site.Data.social.icons "weight" }}
 		{{- if isset $.Site.Params.Social .id }}
-		<a class="social__link" target="_blank" rel="noopener noreferrer" href="{{ printf .url (index $.Site.Params.Social .id) }}">
+		{{- $url := ""}}
+		{{- if eq .id "mastodon"}}
+			{{- $raw := (index $.Site.Params.Social .id)}}
+			{{- $parts := split $raw "@"}}
+			{{- $instance := "mastodon.social"}}
+			{{- $username := $raw}}
+			{{- if eq (len $parts) 1}}
+				{{- /* maintain compat with original (see #8) */}}
+			{{- else if eq (len $parts) 2}}
+				{{- if eq (index $parts 0) ""}}
+					{{- /* parse local usernames relative to mastodon.social */}}
+					{{- if eq (index $parts 1) ""}}
+						{{errorf "failed to parse mastodon username %q: no username or instance" $raw}}
+					{{end}}
+					{{- $username = index $parts 1}}
+				{{- else}}
+					{{- /* parse usernames written in email format */}}
+					{{- if eq (index $parts 1) ""}}
+						{{errorf "failed to parse mastodon username %q: invalid format" $raw}}
+					{{end}}
+					{{- $username = index $parts 0}}
+					{{- $instance = index $parts 1}}
+				{{- end}}
+			{{- else if eq (len $parts) 3}}
+				{{- /* parse mastodon usernames written correctly */}}
+				{{- if ne (index $parts 0) ""}}
+					{{errorf "failed to parse mastodon username %q: leading garbage" $raw}}
+				{{end}}
+				{{- if eq (index $parts 1) ""}}
+					{{errorf "failed to parse mastodon username %q: missing username" $raw}}
+				{{end}}
+				{{- if eq (index $parts 2) ""}}
+					{{errorf "failed to parse mastodon username %q: missing instance" $raw}}
+				{{- end}}
+				{{- $username = index $parts 1}}
+				{{- $instance = index $parts 2}}
+			{{- else}}
+				{{errorf "failed to parse mastodon username %q: too many @'s" $raw}}
+			{{end}}
+			{{- $url = printf .url $instance $username}}
+		{{- else}}
+			{{- $url = printf .url (index $.Site.Params.Social .id)}}
+		{{- end}}
+		<a class="social__link" target="_blank" rel="noopener noreferrer" href="{{ $url }}">
 			{{ partial .icon (dict "class" "social__icon") }}
 		</a>
 		{{- end }}

--- a/layouts/partials/footer_social_mastodonurl.tmpl
+++ b/layouts/partials/footer_social_mastodonurl.tmpl
@@ -1,0 +1,35 @@
+{{- $raw := .}}
+{{- $parts := split $raw "@"}}
+{{- $definstance := "mastodon.social"}}
+{{- if eq (len $parts) 1}}
+	{{- /* maintain compat with original (see #8) */}}
+	{{- printf "https://%s/@%s" $definstance $raw}}
+{{- else if eq (len $parts) 2}}
+	{{- if eq (index $parts 0) ""}}
+		{{- /* parse local usernames relative to mastodon.social */}}
+		{{- if eq (index $parts 1) ""}}
+			{{errorf "failed to parse mastodon username %q: no username or instance" $raw}}
+		{{end}}
+		{{- printf "https://%s/@%s" $definstance (index $parts 1)}}
+	{{- else}}
+		{{- /* parse usernames written in email format */}}
+		{{- if eq (index $parts 1) ""}}
+			{{errorf "failed to parse mastodon username %q: invalid format" $raw}}
+		{{end}}
+		{{- printf "https://%s/@%s" (index $parts 1) (index $parts 0)}}
+	{{- end}}
+{{- else if eq (len $parts) 3}}
+	{{- /* parse mastodon usernames written correctly */}}
+	{{- if ne (index $parts 0) ""}}
+		{{errorf "failed to parse mastodon username %q: leading garbage" $raw}}
+	{{end}}
+	{{- if eq (index $parts 1) ""}}
+		{{errorf "failed to parse mastodon username %q: missing username" $raw}}
+	{{end}}
+	{{- if eq (index $parts 2) ""}}
+		{{errorf "failed to parse mastodon username %q: missing instance" $raw}}
+	{{- end}}
+	{{- printf "https://%s/@%s" (index $parts 2) (index $parts 1)}}
+{{- else}}
+	{{errorf "failed to parse mastodon username %q: too many @'s" $raw}}
+{{end}}


### PR DESCRIPTION
This adds proper support for mastodon usernames by adding a special case to `footer_social.html` for `mastodon`. Let me know if you would like any stylistic changes or if you would like for me to reorganize anything.

I am running a copy with this patch on my personal website: https://jadendw.dev/

This fixes #8 