### PR TITLE
Social: Pass Mastodon URLs Instead of mastodon.social Usernames

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ googleAnalytics = "" # Enable Google Analytics by entering your tracking id
   github = "username"
   gitlab = "username"
   stackoverflow = "numberid"
-  mastodon = "username"
+  mastodon = "https://some.instance/@username"
   medium = "username"
 
 [Params.Share] # Post Share block

--- a/data/social.toml
+++ b/data/social.toml
@@ -66,7 +66,7 @@ weight = 110
 
 [[icons]]
 id = "mastodon"
-url = "https://mastodon.social/@%s"
+url = "%s"
 icon = "svg/mastodon.svg"
 weight = 120
 


### PR DESCRIPTION
Resolves #8 