### PR TITLE
Fix broken homepage on Hugo 0.57+

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -6,7 +6,7 @@
 		</div>
 		{{- end }}
 		{{- $mainSections := .Site.Params.mainSections }}
-		{{- $paginator := .Paginate (where .Data.Pages "Section" "in" $mainSections) }}
+		{{- $paginator := .Paginate (where .Site.RegularPages "Type" "in" $mainSections) }}
 		{{- if gt $paginator.TotalNumberOfElements 0 }}
 			<div class="cards">
 				{{- range $paginator.Pages }}


### PR DESCRIPTION
Hugo 0.57 breaks mainSections logic and how the home section works.
Switch to .Site.RegularPages for the home page paginator to restore old
behavior.