### PR TITLE
Improve look & feel of the main menu on desktop

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -606,6 +606,21 @@ button:not(:-moz-focusring):focus > .main-nav__btn-box {
 		border: 0;
 	}
 
+	.main-nav__item--active {
+		padding: .625rem .625rem .5rem;
+		border-bottom: 2px solid #888;
+	}
+
+	.main-nav__link {
+		padding: .625rem .625rem .5rem;
+		border-bottom: 2px solid transparent;
+	}
+
+	.main-nav__link:hover {
+		text-decoration: none;
+		border-color: #666;
+	}
+
 	.main-nav__list--right {
 		margin-left: auto;
 	}
@@ -613,10 +628,6 @@ button:not(:-moz-focusring):focus > .main-nav__btn-box {
 	.main-nav__list.main-nav__list--active {
 		position: initial;
 		border: 0;
-	}
-
-	.main-nav__link {
-		padding: .625rem;
 	}
 }
 


### PR DESCRIPTION
This is a detail and might be just a matter of taste, but this version of the main menu looks cleaner for me.

**Main Menu Before:**

![Binario main menu before](https://user-images.githubusercontent.com/21033483/66408001-25dee980-e9bc-11e9-8313-a327b292cc3f.png)

**Main Menu After:**

![Binario-after](https://user-images.githubusercontent.com/21033483/66408032-31caab80-e9bc-11e9-8d0f-3ff8f7fd733d.png)
