### PR TITLE
We fixed this bug with symbol "#".

### DIFF
--- a/layouts/partials/entry/meta/categories.html
+++ b/layouts/partials/entry/meta/categories.html
@@ -2,7 +2,7 @@
 <span class="entry__meta-categories meta-categories">
 	<span class="meta-categories__list">{{ T "meta_categories" }}:
 	{{- range $index, $category := .Params.categories }}{{ if gt $index 0 }}, {{ end }}
-		<a class="meta-categories__link" href="{{ "categories/" | relLangURL }}{{ . | urlize | lower }}" rel="category">
+		<a class="meta-categories__link" href="{{ "categories/" replace . "#" "%23" | relLangURL }}{{ . | urlize | lower }}" rel="category">
 			{{- . -}}
 		</a>
 	{{- end }}

--- a/layouts/partials/entry/tags.html
+++ b/layouts/partials/entry/tags.html
@@ -2,10 +2,10 @@
 {{- with .Param $taxo }}
 <div class="entry__tags">
 	{{- range . }}
-		{{- $url := urls.Parse (. | urlize) -}}
+		{{- $url := urls.Parse ( replace . "#" "%23" | urlize) -}}
 		{{- $path := $url.Path -}}
-		{{- with $.Site.GetPage (printf "/%s/%s" $taxo $path) }}
-			<a class="entry__tag btn" href="{{ .RelPermalink }}">{{ .Title }}</a>
+		{{- with $.Site.GetPage (printf "/%s/%s" $taxo $path ) }}
+			<a class="entry__tag btn" href="{{ replace  .RelPermalink  "#" "%23"}}">{{ .Title }}</a>
 		{{- end }}
 	{{- end }}
 </div>


### PR DESCRIPTION
If we have a tag named C#, the url is http://localhost:1313/tags/c#/ , this url show 404 page.
Symbol "#" in url is Special characters. Then we change the # to %23, then it works.

See https://github.com/Vimux/Binario/issues/28

I am not sure whether there is a better solution.

Fix #27