### PR TITLE
Add left border line to hamburger active menu item

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -238,7 +238,8 @@ button:not(:-moz-focusring):focus > .main-nav__btn-box {
 }
 
 .main-nav__item--active {
-	padding: .625rem .875rem;
+	padding: .625rem .875rem .625rem .625rem;
+	border-left: 4px solid #888;
 }
 
 .main-nav__item--active:hover {


### PR DESCRIPTION
This PR adds left borderline to hamburger active menu item and highlights it better.

**Screenshots:**

<details>
  <summary>Before</summary>
  <img src="https://user-images.githubusercontent.com/21033483/121816258-984fa480-cc48-11eb-89b9-173cbad3f7d3.png" alt="Binario hamburger menu before change">
</details>

<details>
  <summary>After</summary>
  <img src="https://user-images.githubusercontent.com/21033483/121816281-b0bfbf00-cc48-11eb-8fb0-e864056b0202.png" alt="Binario hamburger menu after change">
</details>