### PR TITLE
Unify main menu hover appearance for desktop and mobile

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -248,7 +248,13 @@ button:not(:-moz-focusring):focus > .main-nav__btn-box {
 
 .main-nav__link {
 	display: block;
-	padding: .625rem .875rem;
+	padding: .625rem .875rem .625rem .625rem;
+	border-left: 4px solid transparent;
+}
+
+.main-nav__link:hover {
+	text-decoration: none;
+	border-color: #666;
 }
 
 .main-nav__list {
@@ -310,11 +316,7 @@ button:not(:-moz-focusring):focus > .main-nav__btn-box {
 	.main-nav__link {
 		padding: .625rem .625rem .5rem;
 		border-bottom: 2px solid transparent;
-	}
-
-	.main-nav__link:hover {
-		text-decoration: none;
-		border-color: #666;
+		border-left: 0;
 	}
 
 	.main-nav--right {


### PR DESCRIPTION
Now the hover appearance of the mobile and desktop menu looks more uniform for all devices.

**Screenshots:**

<details>
  <summary>Mobile main menu before</summary>
  <img src="https://user-images.githubusercontent.com/21033483/122091411-c4009500-cdd6-11eb-970c-ff0967304f23.png" alt="Binario hamburger menu before main menu hover unification change">
</details>

<details>
  <summary>Mobile main menu after</summary>
  <img src="https://user-images.githubusercontent.com/21033483/122091528-e4305400-cdd6-11eb-9099-4f9d97aa480d.png" alt="Binario hamburger menu after main menu hover unification change">
</details>
