### PR TITLE
Simplify CSS for TOC block

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -485,26 +485,17 @@ button:not(:-moz-focusring):focus > .main-nav__btn-box {
 	padding: .5rem 0 .5rem .5rem;
 }
 
-.toc ul {
-	padding: 0;
-	margin: 0;
-	list-style: none;
-}
-
-.toc ul ul ul a {
+.toc nav ul {
 	padding-left: 25px;
 }
 
-.toc ul ul ul ul a {
-	padding-left: 45px;
+.toc nav ul li {
+	list-style: none;
 }
 
-.toc ul ul ul ul ul a {
-	padding-left: 65px;
-}
-
-.toc ul ul ul ul ul ul a {
-	padding-left: 85px;
+.toc nav > ul {
+	padding: 0;
+	margin: 0;
 }
 
 .entry__footer {


### PR DESCRIPTION
This PR simplifies TOC block CSS. Motivation: fix #22 properly. Not perfect, but fixes Goldmark and respect blackfriday simultaneously (looks slightly different now).

See screenshots below for comparison.

<details>
  <summary>Before</summary>

  | Goldmark                      | blackfriday                   |
  |-----------------------|-----------------------|
  | [![Before PR Goldmark](https://user-images.githubusercontent.com/21033483/124391815-4981b180-dcc0-11eb-983d-54c2b502b376.png)](https://user-images.githubusercontent.com/21033483/124391815-4981b180-dcc0-11eb-983d-54c2b502b376.png) | [![Before PR blackfriday](https://user-images.githubusercontent.com/21033483/124391830-5bfbeb00-dcc0-11eb-8e42-6396f6ae6b37.png)](https://user-images.githubusercontent.com/21033483/124391830-5bfbeb00-dcc0-11eb-8e42-6396f6ae6b37.png) |

</details>

<details>
  <summary>After</summary>

  | Goldmark                      | blackfriday                   |
  |-----------------------|-----------------------|
  | [![After PR Goldmark](https://user-images.githubusercontent.com/21033483/124391877-ada47580-dcc0-11eb-8102-2b4995f16765.png)](https://user-images.githubusercontent.com/21033483/124391877-ada47580-dcc0-11eb-8102-2b4995f16765.png) | [![After PR blackfriday](https://user-images.githubusercontent.com/21033483/124391857-82ba2180-dcc0-11eb-9c6d-b7827da34111.png)](https://user-images.githubusercontent.com/21033483/124391857-82ba2180-dcc0-11eb-9c6d-b7827da34111.png) |

</details>
  
---

Fixes #22

Closes #41
