### PR TITLE
The param is mainSections not mainSection

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -30,13 +30,13 @@
   translation: "You don't have any posts yet!"
 
 - id: empty_text_start
-  translation: "As posts are added in your <code>mainSection</code> folders"
+  translation: "As posts are added in your <code>mainSections</code> folders"
 
 - id: empty_text_end
   translation: "they'll appear here"
 
 - id: empty_tip
-  translation: "<b>Tip:</b> You could change <code>mainSection</code> folders in site config file."
+  translation: "<b>Tip:</b> You could change <code>mainSections</code> folders in site config file."
 
 # 404
 - id: page404_title

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -30,13 +30,13 @@
   translation: "Aucune publication pour le moment"
 
 - id: empty_text_start
-  translation: "Lorsque vous ajouterez des publication dans vos dossiers <code>mainSection</code>"
+  translation: "Lorsque vous ajouterez des publication dans vos dossiers <code>mainSections</code>"
 
 - id: empty_text_end
   translation: "elles arriveront ici"
 
 - id: empty_tip
-  translation: "<b>Astuce:</b> Vous pouvez changer les dossiers <code>mainSection</code> dans le fichier de configuration du site."
+  translation: "<b>Astuce:</b> Vous pouvez changer les dossiers <code>mainSections</code> dans le fichier de configuration du site."
 
 # 404
 - id: page404_title

--- a/i18n/it.yaml
+++ b/i18n/it.yaml
@@ -30,13 +30,13 @@
   translation: "Non hai ancora nessun post!"
 
 - id: empty_text_start
-  translation: "Man mano che i post vengono aggiunti nelle tue cartelle <code>mainSection</code>"
+  translation: "Man mano che i post vengono aggiunti nelle tue cartelle <code>mainSections</code>"
 
 - id: empty_text_end
   translation: "appariranno qui"
 
 - id: empty_tip
-  translation: "<b>Suggerimento:</b> puoi cambiare le cartelle <code>mainSection</code> dal file di configurazione del sito."
+  translation: "<b>Suggerimento:</b> puoi cambiare le cartelle <code>mainSections</code> dal file di configurazione del sito."
 
 # 404
 - id: page404_title

--- a/i18n/pt-br.yaml
+++ b/i18n/pt-br.yaml
@@ -30,13 +30,13 @@
   translation: "Você ainda não tem postagens!"
 
 - id: empty_text_start
-  translation: "Conforme as postagens são adicionadas no diretório <code>mainSection</code>"
+  translation: "Conforme as postagens são adicionadas no diretório <code>mainSections</code>"
 
 - id: empty_text_end
   translation: "Eles vão aparecendo aqui"
 
 - id: empty_tip
-  translation: "<b>Dica:</b> Você pode alterar o diretório <code>mainSection</code> no site config file."
+  translation: "<b>Dica:</b> Você pode alterar o diretório <code>mainSections</code> no site config file."
 
 # 404
 - id: page404_title

--- a/i18n/pt.yaml
+++ b/i18n/pt.yaml
@@ -30,13 +30,13 @@
   translation: "Você ainda não tem postagens!"
 
 - id: empty_text_start
-  translation: "Conforme as postagens são adicionadas no diretório <code>mainSection</code>"
+  translation: "Conforme as postagens são adicionadas no diretório <code>mainSections</code>"
 
 - id: empty_text_end
   translation: "Eles vão aparecendo aqui"
 
 - id: empty_tip
-  translation: "<b>Dica:</b> Você pode alterar o diretório <code>mainSection</code> no site config file."
+  translation: "<b>Dica:</b> Você pode alterar o diretório <code>mainSections</code> no site config file."
 
 # 404
 - id: page404_title


### PR DESCRIPTION
The text on the default home page when there are no articles currently says `mainSection`, however the correct parameter name is `mainSections` (see [Hugo docs](https://gohugo.io/functions/where/#mainsections)). I updated each of the languages' i18n files to have the correct parameter name.