### PR TITLE
Add tags to entry/meta/tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ googleAnalytics = "" # Enable Google Analytics by entering your tracking id
   hideNoPostsWarning = false # Don't show no posts empty state warning in main page, if true
 
 [Params.Entry]
-  meta = ["date", "categories"] # Enable meta fields in given order
+  meta = ["date", "categories", "tags"] # Enable meta fields in given order
   toc = true # Enable Table of Contents
   tocOpen = true # Open Table of Contents block. Optional
 
@@ -247,6 +247,7 @@ related: true # Enable/disable Related content for specific page
 meta:
   - date
   - categories
+  - tags
 featured:
   url: image.jpg # relative path of the image
   alt: A scale model of the Eiffel tower # alternate text for the image
@@ -316,7 +317,7 @@ may activate meta fields with `meta` parameter under the `[Params.Entry]` config
 
 ```toml
 [Params.Entry]
-  meta = ["date", "categories"]
+  meta = ["date", "categories", "tags"]
 ```
 
 #### Related Content

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -9,6 +9,9 @@
 - id: meta_categories
   translation: "Categories"
 
+- id: meta_tags
+  translation: "Tags"
+
 # Share
 - id: share-caption
   translation: "Share on"

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -9,6 +9,9 @@
 - id: meta_categories
   translation: "Catégories"
 
+- id: meta_tags
+  translation: "Mots-clefs"
+
 # Share
 - id: share-caption
   translation: "Partager sur"

--- a/i18n/it.yaml
+++ b/i18n/it.yaml
@@ -9,6 +9,9 @@
 - id: meta_categories
   translation: "Categorie"
 
+- id: meta_tags
+  translation: "Tag"
+
 # Share
 - id: share-caption
   translation: "Condividi su"

--- a/i18n/pt-br.yaml
+++ b/i18n/pt-br.yaml
@@ -9,6 +9,9 @@
 - id: meta_categories
   translation: "Categorias"
 
+- id: meta_tags
+  translation: "Tags"
+
 # Share
 - id: share-caption
   translation: "Campartilhar no"

--- a/i18n/pt.yaml
+++ b/i18n/pt.yaml
@@ -9,6 +9,9 @@
 - id: meta_categories
   translation: "Categorias"
 
+- id: meta_tags
+  translation: "Tags"
+
 # Share
 - id: share-caption
   translation: "Campartilhar"

--- a/layouts/partials/entry/meta/categories.html
+++ b/layouts/partials/entry/meta/categories.html
@@ -1,5 +1,5 @@
 {{- if .Params.categories }}
-<span class="entry__meta-categories meta-categories">
+<div class="entry__meta-categories meta-categories">
 	<span class="meta-categories__list">{{ T "meta_categories" }}:
 	{{- range $index, $category := .Params.categories }}{{ if gt $index 0 }}, {{ end }}
 		<a class="meta-categories__link" href="{{ "categories/" | relLangURL }}{{ . | urlize | lower }}/" rel="category">
@@ -7,5 +7,5 @@
 		</a>
 	{{- end }}
 	</span>
-</span>
+</div>
 {{- end }}

--- a/layouts/partials/entry/meta/tags.html
+++ b/layouts/partials/entry/meta/tags.html
@@ -1,0 +1,11 @@
+{{- if .Params.tags }}
+<div class="entry__meta-tags meta-tags">
+	<span class="meta-tags__list">{{ T "meta_tags" }}:
+		{{- range $index, $category := .Params.tags }}{{ if gt $index 0 }}, {{ end }}
+		<a class="meta-tags__link" href="{{ " tags/" | relLangURL }}{{ . | urlize | lower }}/" rel="tag">
+			{{- . -}}
+		</a>
+		{{- end }}
+	</span>
+</div>
+{{- end }}


### PR DESCRIPTION
I would like to enable adding "tags" to Params.Entry.meta list

This is to address issue: https://github.com/Vimux/Binario/issues/61

This is an initial version, and I'd appreciate feedback on how to improve this. I haven't ever done html - so it's very likely that I'm missing something here. 

Currently, there are two things which aren't working 100%. 

First, I get a test error, but I don't understand why: 
```
0|[noamler@noamler-mbp]:Binario (tags_meta)$ npm test

> binario@1.0.0 test
> npm run lint


> binario@1.0.0 lint
> npm run lint:css && npm run lint:js && npm run lint:editorconfig


> binario@1.0.0 lint:css
> stylelint static/css/*.css assets/css/*.css


> binario@1.0.0 lint:js
> eslint static/js/*.js


> binario@1.0.0 lint:editorconfig
> editorconfig-checker

layouts/partials/entry/meta/tags.html:
	No final newline expected

1 errors found
```

I don't see that there's a newline at the end of the tags.html file - so I'm not sure why this is happening. 

Second, the Tags section in the summary isn't starting in a new line (see screenshots). I'm not sure how to fix that.
![Screen Shot 2022-03-06 at 16 36 52](https://user-images.githubusercontent.com/4646767/156928583-b3155149-46eb-4ca5-8203-308fd828dfd0.png)
![Screen Shot 2022-03-06 at 16 36 57](https://user-images.githubusercontent.com/4646767/156928584-ffa46be6-e62a-49a4-96d5-d78197fb242d.png)

I tested this using a blog of mine - pointing the themes/binario link to be on my local repo instead of the git submodule. I'd be happy to test otherwise. 
 