### PR TITLE
Fix 18n option in CI for hugo versions > 0.93.0

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -42,6 +42,7 @@ jobs:
           - '0.76.5' # https://github.com/gohugoio/hugo/issues/7822
           # - '0.80.0' # https://github.com/gohugoio/hugo/issues/8340
           - '0.86.1' # https://github.com/gohugoio/hugo/issues/9150
+          - '0.93.3' # https://github.com/gohugoio/hugo/commit/837fdfdf45014e3d5ef3b00b01548b68a4489c5f
           - 'latest'
       fail-fast: true
 
@@ -57,4 +58,9 @@ jobs:
 
       - name: Build with Hugo ${{ matrix.hugo }}
         working-directory: exampleSite
-        run: HUGO_THEME="Binario" hugo --themesDir ../.. --i18n-warnings -v
+        run: |
+          function ver { printf "%03d%03d%03d" $(echo "$1" | tr '.' ' '); }
+          HUGO_VERSION=$(hugo version | grep -Eo '[0-9]\.[0-9]+\.[0-9]+')
+          # The option changed in 0.93.0: https://github.com/gohugoio/hugo/releases/tag/v0.93.0
+          I18N_OPT=$([ $(ver $HUGO_VERSION) -lt $(ver 0.93.0) ] && echo "--i18n-warnings" || echo "--printI18nWarnings")
+          HUGO_THEME="Binario" hugo --themesDir ../.. $I18N_OPT -v


### PR DESCRIPTION
As per [Hugo 0.93.0 release notes](https://github.com/gohugoio/hugo/releases/tag/v0.93.0) one of the options changed from `--i18n-warnings` to `--printI18nWarnings`. 
Currently, the CI is hard-coding using the `--i18n-warnings` option. 

There might be better ways to handle the differences, but this is the cleanest one I came up with (taken from [here](https://stackoverflow.com/a/29394504/1747584))