### PR TITLE
Remove space character from a href to avoid %20 appearing in URL's

### DIFF
--- a/layouts/partials/entry/meta/tags.html
+++ b/layouts/partials/entry/meta/tags.html
@@ -2,7 +2,7 @@
 <div class="entry__meta-tags meta-tags">
 	<span class="meta-tags__list">{{ T "meta_tags" }}:
 		{{- range $index, $category := .Params.tags }}{{ if gt $index 0 }}, {{ end }}
-		<a class="meta-tags__link" href="{{ " tags/" | relLangURL }}{{ . | urlize | lower }}/" rel="tag">
+		<a class="meta-tags__link" href="{{ "tags/" | relLangURL }}{{ . | urlize | lower }}/" rel="tag">
 			{{- . -}}
 		</a>
 		{{- end }}


### PR DESCRIPTION
There's an extra space character in the tags.html file, causing the URL's to be `site.tld/%20tags/<yourtag>`.