### PR TITLE
Add support for canonical links

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,17 @@ relative to the `static` folder of your Hugo site:
 
 All custom JS files will be added before closing body tag of a `baseof.html` file.
 
+#### Enable User Canonical
+
+You can specify an explicit canonical link which helps to set a single source 
+of truth for your page. See [here](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls#rel-canonical-link-method)
+how this helps Google to crawl your page.
+
+```toml
+[Params]
+  enableUserCanonical = true
+```
+
 #### Entry Meta
 
 Entry metadata are relevant information about your entry such as published date, last modified date, category, etc. You

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -21,6 +21,7 @@
 	{{- $cssMain := resources.Get "css/main.css" }}
 	{{- $cssPrint := resources.Get "css/print.css" }}
 	{{- $style := slice $cssReboot $cssMain $cssPrint | resources.Concat "css/bundle.css" }}
+	{{if site.Params.enableUserCanonical}}<link rel="canonical" href="{{ .RelPermalink }}"/>{{end}}
 	<link rel="stylesheet" href="{{ $style.RelPermalink }}">
 	{{- range .Site.Params.customCSS }}
 	<link rel="stylesheet" href="{{ . | relURL }}">


### PR DESCRIPTION
This addresses https://github.com/Vimux/Binario/issues/77

This will allow to add canonical links (like `<link rel="canonical" href="https://example.com/dresses/green-dresses" />`) to the `<head>` section. 

This is useful when setting the source of truth for a page to help Google's indexing: https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls