### PR TITLE
Remove `google_analytics_async.html` include

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -37,11 +37,7 @@
 	<link rel="manifest" href="{{ "manifest.json" | relURL }}">
 	{{- end }}
 	{{- if not .Site.IsServer }}
-		{{- if hasPrefix .Site.GoogleAnalytics "G-" }}
 		{{ template "_internal/google_analytics.html" . }}
-		{{- else }}
-		{{ template "_internal/google_analytics_async.html" . }}
-		{{- end }}
 	{{- end }}
 </head>
 <body class="body kind-{{ .Kind }}">


### PR DESCRIPTION
This PR removes the `google_analytics_async.html` internal template include from the `baseof.html`. GA type check also removed.

The internal Hugo template `google_analytics_async.html` no longer works because Google has removed the version of Google Analytics it uses. The regular internal template (`google_analytics.html`) already handles Google Analytics 4 asynchronously (Requires at least Hugo v0.82.0 or manual override of the internal template `google_analytics.html`.)

Fixes #85