### PR TITLE
Fix deprecated config params (GA, Disqus)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,13 @@ title = "Binario"
 languageCode = "en-us"
 paginate = "10" # Number of elements per page in pagination
 theme = "binario"
-disqusShortname = "" # Enable comments by entering your Disqus shortname
-googleAnalytics = "" # Enable Google Analytics by entering your tracking id
+disqusShortname = "" # DEPRECATED! Use .Services.Disqus.Shortname
+googleAnalytics = "" # DEPRECATED! Use .Services.googleAnalytics.ID
+
+[services.disqus]
+  shortname = "" # Enable Disqus by entering your Disqus shortname
+[services.googleAnalytics]
+  ID = "" # Enable Google Analytics by entering your tracking ID
 
 [Author] # Used in authorbox
   name = "John Doe"

--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -1,4 +1,4 @@
-{{ if and (.Site.DisqusShortname) (.Param "comments") (not .Site.IsServer) }}
+{{ if and (.Site.Config.Services.Disqus.Shortname) (.Param "comments") (not .Site.IsServer) }}
 <section class="comments block">
 	{{ template "_internal/disqus.html" . }}
 </section>


### PR DESCRIPTION
As of Hugo 0.120.0, `.Site.disqusShortname` and `.Site.googleAnalytics` are deprecated. This PR fixes the problem. 

Backward compatible change, new notation supported from Hugo v0.41:
  1. `.Site.Config.Services.Disqus.Shortname` falls back to `.Site.disqusShortname`
  2. `.Site.Config.Services.GoogleAnalytics.ID` falls back to `.Site.googleAnalytics`