### PR TITLE
Fix .Site.IsServer error in Hugo >= 0.132.0

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -35,7 +35,13 @@
 	{{- with ((.Site.GetPage "home").OutputFormats.Get "manifest") }}
 	<link rel="manifest" href="{{ "manifest.json" | relURL }}">
 	{{- end }}
-	{{- if not .Site.IsServer }}
+	{{- $server := "" }}
+	{{- if ge (int (index (split hugo.Version ".") 1)) "120" }}
+		{{- $server = hugo.IsServer }}
+	{{- else }}
+		{{- $server = .Site.IsServer }}
+	{{- end }}
+	{{- if not $server -}}
 		{{ template "_internal/google_analytics.html" . }}
 	{{- end }}
 </head>


### PR DESCRIPTION
The `.Site.IsServer` no longer works since Hugo v0.132.0. Use `hugo.IsServer` since Hugo v0.120.0