### PR TITLE
Fix .Site.IsServer error in Hugo >= 0.132.0 [2]

### DIFF
--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -1,5 +1,11 @@
-{{ if and (.Site.Config.Services.Disqus.Shortname) (.Param "comments") (not .Site.IsServer) }}
+{{- $server := "" }}
+{{- if ge (int (index (split hugo.Version ".") 1)) "120" }}
+	{{- $server = hugo.IsServer }}
+{{- else }}
+	{{- $server = .Site.IsServer }}
+{{- end }}
+{{- if and (.Site.Config.Services.Disqus.Shortname) (.Param "comments") (not $server) }}
 <section class="comments block">
 	{{ template "_internal/disqus.html" . }}
 </section>
-{{ end }}
+{{- end }}


### PR DESCRIPTION
The second part of the fix, fixes the comments.html. The `.Site.IsServer` no longer works since Hugo v0.132.0. Use `hugo.IsServer` since Hugo v0.120.0.

Related 8b4c646cb0b168ce7fb0dcc3b5cc4ffe81a639a8
See #94